### PR TITLE
Add changes to make the library usable as an external dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-/.build
+.build
 /Packages
 xcuserdata/
 DerivedData/

--- a/Sources/Testcontainers/GenericContainer.swift
+++ b/Sources/Testcontainers/GenericContainer.swift
@@ -16,7 +16,7 @@ public final class GenericContainer {
     private var container: Docker.Container?
     private var image: Docker.Image?
     
-    init(name: String, configuration: ContainerConfig) {
+    public init(name: String, configuration: ContainerConfig) {
         self.name = name
         self.configuration = configuration
         
@@ -28,7 +28,7 @@ public final class GenericContainer {
         self.docker = Docker(client: client)
     }
     
-    convenience init(name: String, port: Int) {
+    public convenience init(name: String, port: Int) {
         let configuration: ContainerConfig = .build(image: name, exposed: port)
         self.init(name: name, configuration: configuration)
     }


### PR DESCRIPTION

With this, the library can be included as an external dependency:

```swift
        .package(url: "https://github.com/cristianpalomino/testcontainers-swift.git", branch: "main"),
```

Then, the `GenericContainer` init can be used externally:

```swift
import Testcontainers
....
let container = GenericContainer(name: "rabbitmq", port: 5672)
```