### PR TITLE
Some improvements in logging (using swift-log)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "0ae99db85b2b9d1e79b362bd31fd1ffe492f7c47",
-          "version": "1.21.2"
+          "revision": "6df8e1c17e68f0f93de2443b8c8cafca9ddcc89a",
+          "version": "1.22.2"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
-          "revision": "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
-          "version": "1.1.2"
+          "revision": "671108c96644956dddcd89dd59c203dcdb36cec7",
+          "version": "1.1.4"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "e4abde8be0e49dc7d66e6eed651254accdcd9533",
-          "version": "2.69.0"
+          "revision": "1b33db2dea6a64d5b619b9e888175133c6d7f410",
+          "version": "2.73.0"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "05c36b57453d23ea63785d58a7dbc7b70ba1745e",
-          "version": "1.23.0"
+          "revision": "d1ead62745cc3269e482f1c51f27608057174379",
+          "version": "1.24.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "a0224f3d20438635dd59c9fcc593520d80d131d0",
-          "version": "1.33.0"
+          "revision": "b5f7062b60e4add1e8c343ba4eb8da2e324b3a94",
+          "version": "1.34.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "2b09805797f21c380f7dc9bedaab3157c5508efb",
-          "version": "2.27.0"
+          "revision": "7b84abbdcef69cc3be6573ac12440220789dcd69",
+          "version": "2.27.2"
         }
       },
       {

--- a/Sources/Testcontainers/Common/HTTPClientResponse.swift
+++ b/Sources/Testcontainers/Common/HTTPClientResponse.swift
@@ -12,10 +12,15 @@ import NIOCore
 import AsyncHTTPClient
 
 final class HTTPClientResponse: HTTPClientResponseDelegate {
-    
-    let logger: Logger = Logger(label: String(describing: HTTPClientResponse.self))
+
+    let logger: Logger
+
+    init(logger: Logger = Logger(label: String(describing: HTTPClientResponse.self))) {
+        self.logger = logger
+    }
+
     var response: Data = Data()
-    
+
     func didReceiveHead(task: HTTPClient.Task<Data>, _ head: HTTPResponseHead) -> EventLoopFuture<Void> {
         switch head.status.code {
         case 200..<300:
@@ -36,7 +41,7 @@ final class HTTPClientResponse: HTTPClientResponseDelegate {
             return task.eventLoop.makeFailedFuture("Unexpected status code: \(head.status)")
         }
     }
-    
+
     func didReceiveBodyPart(task: HTTPClient.Task<Data>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
         var mutableBuffer = buffer
         if let chunk = buffer.getString(at: 0, length: buffer.readableBytes),
@@ -48,11 +53,11 @@ final class HTTPClientResponse: HTTPClientResponseDelegate {
         }
         return task.eventLoop.makeSucceededFuture(())
     }
-    
+
     func didFinishRequest(task: AsyncHTTPClient.HTTPClient.Task<Data>) throws -> Data {
         return response
     }
-    
+
     func didReceiveError(task: HTTPClient.Task<Data>, _ error: Error) {
         logger.debug("Request failed with error: \(String(describing: error))")
     }

--- a/Sources/Testcontainers/Common/HTTPClientResponse.swift
+++ b/Sources/Testcontainers/Common/HTTPClientResponse.swift
@@ -19,7 +19,7 @@ final class HTTPClientResponse: HTTPClientResponseDelegate {
     func didReceiveHead(task: HTTPClient.Task<Data>, _ head: HTTPResponseHead) -> EventLoopFuture<Void> {
         switch head.status.code {
         case 200..<300:
-            logger.info("Request succeeded with status: \(head.status)")
+            logger.debug("Request succeeded with status: \(head.status)")
             return task.eventLoop.makeSucceededFuture(())
         case 300..<400:
             logger.warning("Request resulted in a redirection with status: \(head.status)")
@@ -42,9 +42,9 @@ final class HTTPClientResponse: HTTPClientResponseDelegate {
         if let chunk = buffer.getString(at: 0, length: buffer.readableBytes),
            let bytes = mutableBuffer.readBytes(length: buffer.readableBytes) {
             response.append(Data(bytes))
-            logger.info("Chunk: \(chunk)")
+            logger.debug("Chunk: \(chunk)")
         } else {
-            logger.info("Received chunk of data but could not decode to string.")
+            logger.debug("Received chunk of data but could not decode to string.")
         }
         return task.eventLoop.makeSucceededFuture(())
     }
@@ -54,6 +54,6 @@ final class HTTPClientResponse: HTTPClientResponseDelegate {
     }
     
     func didReceiveError(task: HTTPClient.Task<Data>, _ error: Error) {
-        logger.error("Request failed with error: \(String(describing: error))")
+        logger.debug("Request failed with error: \(String(describing: error))")
     }
 }

--- a/Sources/Testcontainers/Common/Request+HTTPClientRequest.swift
+++ b/Sources/Testcontainers/Common/Request+HTTPClientRequest.swift
@@ -30,12 +30,8 @@ extension Request {
                 body: .data(body)
             )
             
-            let log = """
-            \nSending
-            URL: \(request.url)|\(request.method)
-            Body: \(String(data: body, encoding: .utf8) ?? "-")
-            """
-            logger.info(Logger.Message(stringLiteral: log))
+            let encodedBody = String(data: body, encoding: .utf8) ?? "-"
+            logger.debug("Sending URL: \(request.url)|\(request.method), Body: \(encodedBody)")
             
             return request
         } catch {

--- a/Sources/Testcontainers/Common/Request+HTTPClientRequest.swift
+++ b/Sources/Testcontainers/Common/Request+HTTPClientRequest.swift
@@ -11,16 +11,16 @@ import NIOHTTP1
 import Logging
 
 extension Request {
-    
+
     func make(host: String, logger: Logger) -> HTTPClient.Request {
         let endpoint = applyQueriesIfAvailable(to: applyParamsIfAvailable())
-        
+
         let url = (host.contains("http")) ? URL(string: "\(host)\(endpoint)") : URL(httpURLWithSocketPath: host, uri: endpoint)
-        
+
         guard let url = url else {
             fatalError("Unable to create a valid URL.")
         }
-        
+
         do {
             let body = try encode(body)
             let request = try HTTPClient.Request(
@@ -29,10 +29,10 @@ extension Request {
                 headers: headers,
                 body: .data(body)
             )
-            
+
             let encodedBody = String(data: body, encoding: .utf8) ?? "-"
             logger.debug("Sending URL: \(request.url)|\(request.method), Body: \(encodedBody)")
-            
+
             return request
         } catch {
             fatalError(String(describing: error))

--- a/Sources/Testcontainers/Docker/Docker+Container.swift
+++ b/Sources/Testcontainers/Docker/Docker+Container.swift
@@ -30,31 +30,31 @@ extension Docker.Container {
 
     func start() -> EventLoopFuture<Void> {
         let request = Docker.Container.Request.Start(id: id)
-        logger.info("Starting container \(id)...")
+        logger.info("📦 Starting container \(id)...")
         return client.send(request)
     }
 
     func inspect() -> EventLoopFuture<ContainerInspectInfo> {
         let request = Docker.Container.Request.Get(id: id)
-        logger.debug("Inspecting container \(id)...")
+        logger.debug("🔍 Inspecting container \(id)...")
         return client.send(request)
     }
 
     func stop() -> EventLoopFuture<Void> {
         let request = Docker.Container.Request.Stop(id: id)
-        logger.info("Stopping container \(id)...")
+        logger.info("📦 Stopping container \(id)...")
         return client.send(request)
     }
 
     func remove() -> EventLoopFuture<Void> {
         let request = Docker.Container.Request.Remove(id: id)
-        logger.debug("Removing container \(id)...")
+        logger.info("📦 Removing container \(id)...")
         return client.send(request)
     }
 
     func kill() -> EventLoopFuture<Void> {
         let request = Docker.Container.Request.Remove(id: id)
-        logger.warning("Killing container \(id)...")
+        logger.warning("⚠ Killing container \(id)...")
         return client.send(request)
     }
 }

--- a/Sources/Testcontainers/Docker/Docker+Container.swift
+++ b/Sources/Testcontainers/Docker/Docker+Container.swift
@@ -8,45 +8,53 @@
 import Foundation
 import NIOHTTP1
 import NIOCore
+import Logging
 
 extension Docker {
-    
+
     final class Container {
-        
+
         let id: String
         let client: DockerClientProtocol
-        
-        init(id: String, client: DockerClientProtocol) {
+        let logger: Logger
+
+        init(id: String, client: DockerClientProtocol, logger: Logger) {
             self.id = id
             self.client = client
+            self.logger = logger
         }
     }
 }
 
 extension Docker.Container {
-    
+
     func start() -> EventLoopFuture<Void> {
         let request = Docker.Container.Request.Start(id: id)
+        logger.info("Starting container \(id)...")
         return client.send(request)
     }
-    
+
     func inspect() -> EventLoopFuture<ContainerInspectInfo> {
         let request = Docker.Container.Request.Get(id: id)
+        logger.debug("Inspecting container \(id)...")
         return client.send(request)
     }
-    
+
     func stop() -> EventLoopFuture<Void> {
         let request = Docker.Container.Request.Stop(id: id)
+        logger.info("Stopping container \(id)...")
         return client.send(request)
     }
-    
+
     func remove() -> EventLoopFuture<Void> {
         let request = Docker.Container.Request.Remove(id: id)
+        logger.debug("Removing container \(id)...")
         return client.send(request)
     }
-    
+
     func kill() -> EventLoopFuture<Void> {
         let request = Docker.Container.Request.Remove(id: id)
+        logger.warning("Killing container \(id)...")
         return client.send(request)
     }
 }

--- a/Sources/Testcontainers/Docker/Docker.swift
+++ b/Sources/Testcontainers/Docker/Docker.swift
@@ -23,34 +23,34 @@ extension Docker {
 
     func ping() -> EventLoopFuture<Void> {
         let request = Docker.Request.Ping()
-        logger.debug("Sending ping request to host: \(client.host)")
+        logger.debug("🐳 Sending ping request to host: \(client.host)")
         return client.send(request)
     }
 
     func info() -> EventLoopFuture<Info> {
         let request = Docker.Request.GetInfo()
-        logger.debug("Sending info request to host: \(client.host)")
+        logger.debug("🐳 Sending info request to host: \(client.host)")
         return client.send(request)
     }
 
     func version() -> EventLoopFuture<Version> {
         let request = Docker.Request.GetVersion()
-        logger.debug("Sending version request to host: \(client.host)")
+        logger.debug("🐳 Sending version request to host: \(client.host)")
         return client.send(request)
     }
 
     func pull(params: DockerImageName) -> EventLoopFuture<Docker.Image> {
         let request = Docker.Image.Request.Create(params: params)
-        logger.info("Pulling image \(params.conventionName)...")
+        logger.info("🐳 Pulling image \(params.conventionName)...")
         return client.send(request)
             .map { Docker.Image(params: params, client: self.client) }
     }
 
     func create(container configuration: ContainerConfig) -> EventLoopFuture<Docker.Container> {
         let request = Docker.Container.Request.Create(configuration: configuration)
-        logger.info("Creating container for: \(configuration.Image)")
+        logger.info("📦 Creating container for \(configuration.Image)...")
         return client.send(request).map {
-            self.logger.info("Created container: \($0.Id)")
+            self.logger.info("📦 Created container: \($0.Id)")
             return Docker.Container(id: $0.Id, client: self.client, logger: self.logger) 
         }
     }

--- a/Sources/Testcontainers/Docker/Docker.swift
+++ b/Sources/Testcontainers/Docker/Docker.swift
@@ -48,7 +48,7 @@ extension Docker {
 
     func create(container configuration: ContainerConfig) -> EventLoopFuture<Docker.Container> {
         let request = Docker.Container.Request.Create(configuration: configuration)
-        logger.debug("Creating container: \(configuration)")
+        logger.info("Creating container for: \(configuration.Image)")
         return client.send(request).map {
             self.logger.info("Created container: \($0.Id)")
             return Docker.Container(id: $0.Id, client: self.client, logger: self.logger) 

--- a/Sources/Testcontainers/Docker/Docker.swift
+++ b/Sources/Testcontainers/Docker/Docker.swift
@@ -7,43 +7,52 @@
 
 import Foundation
 import NIOCore
+import Logging
 
 final class Docker {
-    
     let client: DockerClientProtocol
-    
-    init(client: DockerClientProtocol) {
+    let logger: Logger
+
+    init(client: DockerClientProtocol, logger: Logger) {
         self.client = client
+        self.logger = logger
     }
 }
 
 extension Docker {
-    
+
     func ping() -> EventLoopFuture<Void> {
         let request = Docker.Request.Ping()
+        logger.debug("Sending ping request to host: \(client.host)")
         return client.send(request)
     }
-    
+
     func info() -> EventLoopFuture<Info> {
         let request = Docker.Request.GetInfo()
+        logger.debug("Sending info request to host: \(client.host)")
         return client.send(request)
     }
-    
+
     func version() -> EventLoopFuture<Version> {
         let request = Docker.Request.GetVersion()
+        logger.debug("Sending version request to host: \(client.host)")
         return client.send(request)
     }
-    
+
     func pull(params: DockerImageName) -> EventLoopFuture<Docker.Image> {
         let request = Docker.Image.Request.Create(params: params)
+        logger.info("Pulling image \(params.conventionName)...")
         return client.send(request)
             .map { Docker.Image(params: params, client: self.client) }
     }
-    
+
     func create(container configuration: ContainerConfig) -> EventLoopFuture<Docker.Container> {
         let request = Docker.Container.Request.Create(configuration: configuration)
-        return client.send(request)
-            .map { Docker.Container(id: $0.Id, client: self.client) }
+        logger.debug("Creating container: \(configuration)")
+        return client.send(request).map {
+            self.logger.info("Created container: \($0.Id)")
+            return Docker.Container(id: $0.Id, client: self.client, logger: self.logger) 
+        }
     }
 }
 

--- a/Sources/Testcontainers/Docker/Docker.swift
+++ b/Sources/Testcontainers/Docker/Docker.swift
@@ -48,7 +48,7 @@ extension Docker {
 
     func create(container configuration: ContainerConfig) -> EventLoopFuture<Docker.Container> {
         let request = Docker.Container.Request.Create(configuration: configuration)
-        logger.info("📦 Creating container for \(configuration.Image)...")
+        logger.debug("📦 Creating container using configuration: \(configuration)")
         return client.send(request).map {
             self.logger.info("📦 Created container: \($0.Id)")
             return Docker.Container(id: $0.Id, client: self.client, logger: self.logger) 

--- a/Sources/Testcontainers/Docker/Models/DockerImageName.swift
+++ b/Sources/Testcontainers/Docker/Models/DockerImageName.swift
@@ -8,10 +8,14 @@
 import Foundation
 
 public struct DockerImageName {
-    
+
     public let name: String
     public let tag: String
-    
+
+    var conventionName: String {
+        "\(name):\(tag)"
+    }
+
     public init(image: String) throws {
         let items = image.split(separator: ":")
         guard
@@ -21,11 +25,11 @@ public struct DockerImageName {
         else {
             throw "Unable to retrieve \(image), use the next format <name>:<tag>"
         }
-        
+
         self.name = String(name)
         self.tag = String(tag)
     }
-    
+
     public init(name: String, tag: String) {
         self.name = name
         self.tag = tag

--- a/Sources/Testcontainers/GenericContainer.swift
+++ b/Sources/Testcontainers/GenericContainer.swift
@@ -22,7 +22,7 @@ public final class GenericContainer {
         
         guard let client = DockerClientStrategy().resolve() else {
             self.docker = nil
-            self.logger.error("Unable to resolve a Docker client")
+            self.logger.error("❌ Unable to resolve a Docker client")
             return
         }
         self.docker = Docker(client: client)
@@ -67,21 +67,12 @@ public final class GenericContainer {
         let infoFuture = docker.info()
         let versionFuture = infoFuture.and(docker.version())
             .map { info, version in
-                let labels = info.Labels
-                var serverInfo = """
-            \nConnected to docker:
-              Server Version: \(info.ServerVersion)
-              API Version: \(version.ApiVersion)
-              Operating System: \(info.OperatingSystem)
-              Total Memory: \(info.MemTotal / (1024 * 1024)) MB
-            """
-                if !labels.isEmpty {
-                    serverInfo.append("\n  Labels:\n")
-                    labels.forEach { label in
-                        serverInfo.append("    \(label)\n")
-                    }
-                }
-                self.logger.info(Logger.Message(stringLiteral: serverInfo))
+                self.logger.info("🐳 Connected to Docker:")
+                self.logger.info("→ Server Version: \(info.ServerVersion)")
+                self.logger.info("→ API Version: \(version.ApiVersion)")
+                self.logger.info("→ Operating System: \(info.OperatingSystem)")
+                self.logger.info("→ Total Memory: \(info.MemTotal / (1024 * 1024)) MB")
+                self.logger.info("→ Labels: \(info.Labels)")
             }
         
         return versionFuture.flatMap { _ in

--- a/Sources/Testcontainers/GenericContainer.swift
+++ b/Sources/Testcontainers/GenericContainer.swift
@@ -3,6 +3,10 @@ import AsyncHTTPClient
 import Logging
 import NIO
 
+public enum ContainerError: Error {
+    case unableToResolve
+}
+
 public final class GenericContainer {
 
     static let uuid = UUID().uuidString
@@ -11,19 +15,16 @@ public final class GenericContainer {
     private let imageParams: DockerImageName
     private let configuration: ContainerConfig
 
-    private var docker: Docker?
+    private var docker: Docker
     private var container: Docker.Container?
-    private var image: Docker.Image?
 
-    public init(image: DockerImageName, configuration: ContainerConfig, logger: Logger) {
+    public init(image: DockerImageName, configuration: ContainerConfig, logger: Logger) throws {
         self.imageParams = image
         self.configuration = configuration
         self.logger = logger
 
         guard let client = DockerClientStrategy(logger: logger).resolve() else {
-            self.docker = nil
-            self.logger.error("❌ Unable to resolve a Docker client")
-            return
+            throw ContainerError.unableToResolve
         }
         self.docker = Docker(client: client, logger: logger)
     }
@@ -32,9 +33,9 @@ public final class GenericContainer {
         image: DockerImageName,
         port: Int,
         logger: Logger = Logger(label: String(describing: GenericContainer.self))
-    ) {
+    ) throws {
         let configuration: ContainerConfig = .build(image: image.name, tag: image.tag, exposed: port)
-        self.init(image: image, configuration: configuration, logger: logger)
+        try self.init(image: image, configuration: configuration, logger: logger)
     }
 
     public convenience init(
@@ -42,10 +43,10 @@ public final class GenericContainer {
         tag: String = "latest",
         port: Int,
         logger: Logger = Logger(label: String(describing: GenericContainer.self))
-    ) {
+    ) throws {
         let configuration: ContainerConfig = .build(image: name, tag: tag, exposed: port)
         let image = DockerImageName(name: name, tag: tag)
-        self.init(image: image, configuration: configuration, logger: logger)
+        try self.init(image: image, configuration: configuration, logger: logger)
     }
 
     public convenience init(
@@ -55,33 +56,35 @@ public final class GenericContainer {
     ) throws {
         let image = try DockerImageName(image: image)
         let configuration: ContainerConfig = .build(image: image.name, tag: image.tag, exposed: port)
-        self.init(image: image, configuration: configuration, logger: logger)
+        try self.init(image: image, configuration: configuration, logger: logger)
     }
 
-    public func start() -> EventLoopFuture<ContainerInspectInfo> {
-        guard let docker else {
-            return MultiThreadedEventLoopGroup(numberOfThreads: 1).next()
-                .makeFailedFuture("Unable to resolve a Docker client")
+    public func start(retrieveHostInfo: Bool = true) -> EventLoopFuture<ContainerInspectInfo> {
+        if retrieveHostInfo {
+            let infoFuture = docker.info()
+            let versionFuture = infoFuture.and(docker.version())
+                .map { info, version in
+                    self.logger.info("🐳 Connected to Docker:")
+                    self.logger.info("→ Server Version: \(info.ServerVersion)")
+                    self.logger.info("→ API Version: \(version.ApiVersion)")
+                    self.logger.info("→ Operating System: \(info.OperatingSystem)")
+                    self.logger.info("→ Total Memory: \(info.MemTotal / (1024 * 1024)) MB")
+                    self.logger.info("→ Labels: \(info.Labels)")
+                }
+
+            return versionFuture.flatMap { _ in
+                self.createContainer()
+            }
         }
 
-        let infoFuture = docker.info()
-        let versionFuture = infoFuture.and(docker.version())
-            .map { info, version in
-                self.logger.info("🐳 Connected to Docker:")
-                self.logger.info("→ Server Version: \(info.ServerVersion)")
-                self.logger.info("→ API Version: \(version.ApiVersion)")
-                self.logger.info("→ Operating System: \(info.OperatingSystem)")
-                self.logger.info("→ Total Memory: \(info.MemTotal / (1024 * 1024)) MB")
-                self.logger.info("→ Labels: \(info.Labels)")
-            }
+        return createContainer()
+    }
 
-        return versionFuture.flatMap { _ in
-            docker.pull(params: self.imageParams).map { image in
-                self.image = image
-                return image
-            }
+    private func createContainer() -> EventLoopFuture<ContainerInspectInfo> {
+        docker.pull(params: self.imageParams).map { image in
+            return image
         }.flatMap { _ in
-            docker.create(container: self.configuration).map { container in
+            self.docker.create(container: self.configuration).map { container in
                 self.container = container
                 return container
             }
@@ -93,15 +96,12 @@ public final class GenericContainer {
     }
 
     public func remove() -> EventLoopFuture<Void> {
-        guard let docker else {
-            return MultiThreadedEventLoopGroup(numberOfThreads: 1).next()
-                .makeFailedFuture("Unable to resolve a Docker client")
-        }
-
         guard let container = container else {
             return docker.client.eventLoop.next().makeFailedFuture("Container not found")
         }
 
-        return container.kill()
+        return container.stop().flatMap { _ in
+            container.remove()
+        }
     }
 }

--- a/Sources/Testcontainers/GenericContainer.swift
+++ b/Sources/Testcontainers/GenericContainer.swift
@@ -59,12 +59,12 @@ public final class GenericContainer {
         try self.init(image: image, configuration: configuration, logger: logger)
     }
 
-    public func start(retrieveHostInfo: Bool = true) -> EventLoopFuture<ContainerInspectInfo> {
+    public func start(retrieveHostInfo: Bool = false) -> EventLoopFuture<ContainerInspectInfo> {
         if retrieveHostInfo {
             let infoFuture = docker.info()
             let versionFuture = infoFuture.and(docker.version())
                 .map { info, version in
-                    self.logger.info("🐳 Connected to Docker:")
+                    self.logger.info("🐳 Docker Info:")
                     self.logger.info("→ Server Version: \(info.ServerVersion)")
                     self.logger.info("→ API Version: \(version.ApiVersion)")
                     self.logger.info("→ Operating System: \(info.OperatingSystem)")

--- a/Sources/Testcontainers/Strategies/Docker+ClientStrategy.swift
+++ b/Sources/Testcontainers/Strategies/Docker+ClientStrategy.swift
@@ -63,7 +63,7 @@ extension DockerClientStrategyProtocol {
                         switch result {
                         case .success:
                             // Remove percent encoding for pretty-printing
-                            let hostName = URL(string: host)?.host(percentEncoded: false) ?? host
+                            let hostName = URLComponents(string: host)?.host ?? host
                             self.logger.info("🐳 Resolved Docker host at: \(hostName)")
                             client = hostClient
                         case .failure(let error):

--- a/Sources/Testcontainers/Strategies/Docker+ClientStrategy.swift
+++ b/Sources/Testcontainers/Strategies/Docker+ClientStrategy.swift
@@ -62,6 +62,7 @@ extension DockerClientStrategyProtocol {
                     if client == nil {
                         switch result {
                         case .success:
+                            // Remove percent encoding for pretty-printing
                             let hostName = URL(string: host)?.host(percentEncoded: false) ?? host
                             self.logger.info("🐳 Resolved Docker host at: \(hostName)")
                             client = hostClient

--- a/Sources/Testcontainers/Strategies/Docker+ClientStrategy.swift
+++ b/Sources/Testcontainers/Strategies/Docker+ClientStrategy.swift
@@ -39,11 +39,12 @@ extension DockerClientStrategyProtocol {
         let dispatchGroup = DispatchGroup()
         var client: DockerHTTPClient?
         let queue = DispatchQueue(label: "testcontainers.client.strategy")
-        
+
         for host in getHosts() {
             dispatchGroup.enter()
-            logger.info("Resolving host: \(host)")
-            
+            let hostName = URL(string: host)?.host(percentEncoded: false) ?? host
+            logger.info("🔍 Resolving Docker host at: \(hostName)")
+
             let hostClient = DockerHTTPClient(host: host)
             let docker = Docker(client: hostClient)
             
@@ -52,10 +53,10 @@ extension DockerClientStrategyProtocol {
                     if client == nil {
                         switch result {
                         case .success:
-                            self.logger.info("Successfull ping to host: \(host)")
+                            self.logger.debug("Successfull ping to host: \(host)")
                             client = hostClient
                         case .failure(let error):
-                            self.logger.warning("Failed ping to host: \(host), error: \(error)")
+                            self.logger.debug("Failed ping to host: \(host), error: \(error)")
                         }
                     }
                     dispatchGroup.leave()

--- a/Sources/Testcontainers/Strategies/Docker+ClientStrategy.swift
+++ b/Sources/Testcontainers/Strategies/Docker+ClientStrategy.swift
@@ -54,7 +54,7 @@ extension DockerClientStrategyProtocol {
             dispatchGroup.enter()
             logger.debug("Resolving Docker host: \(host)")
 
-            let hostClient = DockerHTTPClient(host: host)
+            let hostClient = DockerHTTPClient(host: host, logger: logger)
             let docker = Docker(client: hostClient, logger: logger)
 
             docker.ping().whenComplete { result in

--- a/Sources/Testcontainers/Strategies/Docker+ClientStrategy.swift
+++ b/Sources/Testcontainers/Strategies/Docker+ClientStrategy.swift
@@ -10,12 +10,22 @@ import Logging
 import NIO
 
 final class DockerClientStrategy {
-    
-    var strategies: [DockerClientStrategyProtocol] = [
-        TestcontainersStrategy(),
-        UnixSocketStrategy()
-    ]
-    
+
+    let logger: Logger
+    let strategies: [DockerClientStrategyProtocol]
+
+    init(logger: Logger, strategies: [DockerClientStrategyProtocol] = []) {
+        self.logger = logger
+        if strategies.isEmpty {
+            self.strategies = [
+                TestcontainersStrategy(logger: logger),
+                UnixSocketStrategy(logger: logger)
+            ]
+        } else {
+            self.strategies = strategies
+        }
+    }
+
     func resolve() -> DockerHTTPClient? {
         for strategy in strategies {
             if let client = strategy.resolve() {
@@ -34,7 +44,7 @@ protocol DockerClientStrategyProtocol {
 }
 
 extension DockerClientStrategyProtocol {
-    
+
     func resolve() -> DockerHTTPClient? {
         let dispatchGroup = DispatchGroup()
         var client: DockerHTTPClient?
@@ -42,18 +52,18 @@ extension DockerClientStrategyProtocol {
 
         for host in getHosts() {
             dispatchGroup.enter()
-            let hostName = URL(string: host)?.host(percentEncoded: false) ?? host
-            logger.info("🔍 Resolving Docker host at: \(hostName)")
+            logger.debug("Resolving Docker host: \(host)")
 
             let hostClient = DockerHTTPClient(host: host)
-            let docker = Docker(client: hostClient)
-            
+            let docker = Docker(client: hostClient, logger: logger)
+
             docker.ping().whenComplete { result in
                 queue.sync {
                     if client == nil {
                         switch result {
                         case .success:
-                            self.logger.debug("Successfull ping to host: \(host)")
+                            let hostName = URL(string: host)?.host(percentEncoded: false) ?? host
+                            self.logger.info("🐳 Resolved Docker host at: \(hostName)")
                             client = hostClient
                         case .failure(let error):
                             self.logger.debug("Failed ping to host: \(host), error: \(error)")
@@ -63,7 +73,7 @@ extension DockerClientStrategyProtocol {
                 }
             }
         }
-        
+
         dispatchGroup.wait()
         return client
     }

--- a/Sources/Testcontainers/Strategies/TestcontainersStrategy.swift
+++ b/Sources/Testcontainers/Strategies/TestcontainersStrategy.swift
@@ -61,7 +61,7 @@ struct TestcontainersStrategy: DockerClientStrategyProtocol {
                 }
             }
         } catch {
-            logger.info("Error reading the file: \(String(describing: error))")
+            logger.debug("Error reading the file: \(String(describing: error))")
         }
         
         return properties

--- a/Sources/Testcontainers/Strategies/TestcontainersStrategy.swift
+++ b/Sources/Testcontainers/Strategies/TestcontainersStrategy.swift
@@ -9,15 +9,15 @@ import Foundation
 import Logging
 
 struct TestcontainersStrategy: DockerClientStrategyProtocol {
-    
-    let logger: Logger = Logger(label: String(describing: TestcontainersStrategy.self))
+    let logger: Logger
     var paths: [String]
-    
-    init(paths: [String] = []) {
+
+    init(logger: Logger, paths: [String] = []) {
+        self.logger = logger
         self.paths = paths
         self.loadPaths()
     }
-    
+
     mutating func loadPaths() {
         let home = FileManager.default.homeDirectoryForCurrentUser
         let path = home.appendingPathComponent(".testcontainers.properties").path
@@ -29,7 +29,7 @@ struct TestcontainersStrategy: DockerClientStrategyProtocol {
             paths.append(dockerHost.replacingOccurrences(of: "tcp", with: "http"))
         }
     }
-    
+
     func getHosts() -> [String] {
         var hosts: [String] = []
         for path in paths {
@@ -37,13 +37,13 @@ struct TestcontainersStrategy: DockerClientStrategyProtocol {
         }
         return hosts
     }
-    
+
     private func loadProperties(from path: String) -> [String: String] {
         var properties: [String: String] = [:]
         do {
             let fileContents = try String(contentsOfFile: path, encoding: .utf8)
             let lines = fileContents.split(separator: "\n")
-            
+
             for line in lines {
                 let trimmedLine = line.trimmingCharacters(in: .whitespaces)
                 if trimmedLine.hasPrefix("#") || trimmedLine.isEmpty {
@@ -63,7 +63,7 @@ struct TestcontainersStrategy: DockerClientStrategyProtocol {
         } catch {
             logger.debug("Error reading the file: \(String(describing: error))")
         }
-        
+
         return properties
     }
 }

--- a/Sources/Testcontainers/Strategies/TestcontainersStrategy.swift
+++ b/Sources/Testcontainers/Strategies/TestcontainersStrategy.swift
@@ -61,7 +61,7 @@ struct TestcontainersStrategy: DockerClientStrategyProtocol {
                 }
             }
         } catch {
-            logger.error("Error reading the file: \(String(describing: error))")
+            logger.debug("Error reading the file \(path): \(String(describing: error))")
         }
 
         return properties

--- a/Sources/Testcontainers/Strategies/TestcontainersStrategy.swift
+++ b/Sources/Testcontainers/Strategies/TestcontainersStrategy.swift
@@ -61,7 +61,7 @@ struct TestcontainersStrategy: DockerClientStrategyProtocol {
                 }
             }
         } catch {
-            logger.debug("Error reading the file: \(String(describing: error))")
+            logger.error("Error reading the file: \(String(describing: error))")
         }
 
         return properties

--- a/Sources/Testcontainers/Strategies/UnixSocketStrategy.swift
+++ b/Sources/Testcontainers/Strategies/UnixSocketStrategy.swift
@@ -9,9 +9,12 @@ import Foundation
 import Logging
 
 final class UnixSocketStrategy: DockerClientStrategyProtocol {
-    
-    let logger: Logger = Logger(label: String(describing: UnixSocketStrategy.self))
-    
+    let logger: Logger
+
+    init(logger: Logger) {
+        self.logger = logger
+    }
+
     var home: URL {
         return FileManager.default.homeDirectoryForCurrentUser
     }
@@ -29,7 +32,7 @@ final class UnixSocketStrategy: DockerClientStrategyProtocol {
             getSocketPathFromRunDir().relativePath
         ]
     }
-    
+
     func getHosts() -> [String] {
         var hosts: [String] = []
         for path in paths {
@@ -48,14 +51,14 @@ final class UnixSocketStrategy: DockerClientStrategyProtocol {
             .appendingPathComponent("run")
             .appendingPathComponent("docker.sock")
     }
-    
+
     private func getSocketPathFromHomeDesktopDir() -> URL {
         return home
             .appendingPathComponent(".docker")
             .appendingPathComponent("desktop")
             .appendingPathComponent("docker.sock")
     }
-    
+
     private func getSocketPathFromRunDir() -> URL {
         let uid = getuid()
         return URL(fileURLWithPath: "/run")

--- a/Tests/TestcontainersTests/TestcontainersTests.swift
+++ b/Tests/TestcontainersTests/TestcontainersTests.swift
@@ -2,21 +2,21 @@ import XCTest
 @testable import Testcontainers
 
 final class TestContainersTests: XCTestCase {
-    
+
     var container: GenericContainer!
-    
+
     override class func tearDown() {
         super.tearDown()
     }
-    
+
     override func tearDownWithError() throws {
         try super.tearDownWithError()
     }
-    
+
     func test_start_ThenRemoveContainer_shouldBeSuccess_async_await() async throws {
         var success = false
         do {
-            container = GenericContainer(name: "redis", port: 6379)
+            container = try GenericContainer(name: "redis", port: 6379)
             let response = try await container.start().get()
             print(response.Name)
             try await container.remove().get()
@@ -27,12 +27,12 @@ final class TestContainersTests: XCTestCase {
             XCTAssertEqual(success, true, String(describing: error))
         }
     }
-    
+
     func test_start_ThenRemoveContainer_shouldBeSuccess() throws {
         let expectation = expectation(description: "test_startThenRemoveContainer_shouldBeSuccess")
         var success = false
-        
-        container = GenericContainer(name: "redis", port: 6379)
+
+        container = try GenericContainer(name: "redis", port: 6379)
         container
             .start()
             .map { _ in self.container }
@@ -51,16 +51,16 @@ final class TestContainersTests: XCTestCase {
                 }
                 expectation.fulfill()
             }
-        
+
         waitForExpectations(timeout: 120)
     }
-    
-    
+
+
     // TODO: Improve the unit tests
     func test_startUsingTag_ThenRemoveContainer_shouldBeSuccess() throws {
         let expectation = expectation(description: "test_startUsingTag_ThenRemoveContainer_shouldBeSuccess")
         var success = false
-        
+
         // container = GenericContainer(name: "rabbitmq", tag: "3-alpine", port: 6379)
         // let params = ImageParams(name: "redis", tag: "7.2.5", src: nil, repo: nil)
         // container = GenericContainer(image: params, port: 6379)
@@ -83,7 +83,7 @@ final class TestContainersTests: XCTestCase {
                 }
                 expectation.fulfill()
             }
-        
+
         waitForExpectations(timeout: 120)
     }
 }

--- a/Tests/TestcontainersTests/TestcontainersTests.swift
+++ b/Tests/TestcontainersTests/TestcontainersTests.swift
@@ -1,9 +1,16 @@
 import XCTest
+import Logging
+
 @testable import Testcontainers
 
 final class TestContainersTests: XCTestCase {
 
-    var container: GenericContainer!
+    var logger: Logger = Logger(label: String(describing: TestContainersTests.self))
+
+    required init(name: String, testClosure: @escaping XCTestCaseClosure) {
+        super.init(name: name, testClosure: testClosure)
+        logger.logLevel = .info
+    }
 
     override class func tearDown() {
         super.tearDown()
@@ -15,10 +22,11 @@ final class TestContainersTests: XCTestCase {
 
     func test_start_ThenRemoveContainer_shouldBeSuccess_async_await() async throws {
         var success = false
+
         do {
-            container = try GenericContainer(name: "redis", port: 6379)
+            let container = try GenericContainer(name: "redis", port: 6379, logger: logger)
             let response = try await container.start().get()
-            print(response.Name)
+            logger.info("Container Name: \(response.Name)")
             try await container.remove().get()
             success = true
             XCTAssertEqual(success, true)
@@ -32,17 +40,16 @@ final class TestContainersTests: XCTestCase {
         let expectation = expectation(description: "test_startThenRemoveContainer_shouldBeSuccess")
         var success = false
 
-        container = try GenericContainer(name: "redis", port: 6379)
+        let container = try GenericContainer(name: "redis", port: 6379, logger: logger)
         container
             .start()
-            .map { _ in self.container }
+            .map { _ in container }
             .flatMap { container in
                 container.remove()
             }
             .whenComplete { result in
                 switch result {
-                case let .success(response):
-                    print(response)
+                case .success:
                     success = true
                     XCTAssertEqual(success, true)
                 case let .failure(error):
@@ -64,17 +71,16 @@ final class TestContainersTests: XCTestCase {
         // container = GenericContainer(name: "rabbitmq", tag: "3-alpine", port: 6379)
         // let params = ImageParams(name: "redis", tag: "7.2.5", src: nil, repo: nil)
         // container = GenericContainer(image: params, port: 6379)
-        container = try GenericContainer(image: "redis:7.2.5", port: 6379)
+        let container = try GenericContainer(image: "redis:7.2.5", port: 6379, logger: logger)
         container
             .start()
-            .map { _ in self.container }
+            .map { _ in container }
             .flatMap { container in
                 container.remove()
             }
             .whenComplete { result in
                 switch result {
-                case let .success(response):
-                    print(response)
+                case .success:
                     success = true
                     XCTAssertEqual(success, true)
                 case let .failure(error):


### PR DESCRIPTION
I am marking this draft since I think it could be improved, but I want you to see what I've done so far. It's looking nicer now. By default the `Logger` level is `.info`, and this is what you get:

```bash
Test Case 'TestContainersTests.test_start_ThenRemoveContainer_shouldBeSuccess_async_await' started at 2024-10-19 14:52:03.064
2024-10-19T14:52:03-0400 info TestContainersTests : [Testcontainers] 🐳 Resolved Docker host at: /var/run/docker.sock
2024-10-19T14:52:13-0400 info TestContainersTests : [Testcontainers] 🐳 Pulling image redis:latest...
2024-10-19T14:52:13-0400 info TestContainersTests : [Testcontainers] 📦 Created container: 4b2abec46ddecd40baaed3558fab0802d65e21b3064acc2fe7d8ecc88d3626b0
2024-10-19T14:52:13-0400 info TestContainersTests : [Testcontainers] 📦 Starting container 4b2abec46ddecd40baaed3558fab0802d65e21b3064acc2fe7d8ecc88d3626b0...
2024-10-19T14:52:13-0400 info TestContainersTests : [TestcontainersTests] Container Name: /objective_mestorf
2024-10-19T14:52:13-0400 info TestContainersTests : [Testcontainers] 📦 Stopping container 4b2abec46ddecd40baaed3558fab0802d65e21b3064acc2fe7d8ecc88d3626b0...
2024-10-19T14:52:14-0400 info TestContainersTests : [Testcontainers] 📦 Removing container 4b2abec46ddecd40baaed3558fab0802d65e21b3064acc2fe7d8ecc88d3626b0...
Test Case 'TestContainersTests.test_start_ThenRemoveContainer_shouldBeSuccess_async_await' passed (11.247 seconds)
```

However, if you set the logger to `.debug`, you see a lot more info from the various modules, and it's pretty verbose:

```bash
Test Case 'TestContainersTests.test_start_ThenRemoveContainer_shouldBeSuccess' started at 2024-10-19 14:56:17.405
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] Error reading the file /home/xtremek/.testcontainers.properties: Error Domain=NSCocoaErrorDomain Code=260 "The file doesn’t exist."
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] Resolving Docker host: http+unix://%2Fvar%2Frun%2Fdocker.sock
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] 🐳 Sending ping request to host: http+unix://%2Fvar%2Frun%2Fdocker.sock
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] Sending URL: http+unix://%2Fvar%2Frun%2Fdocker.sock/_ping|GET, Body: null
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] Resolving Docker host: http+unix://%2Fhome%2Fxtremek%2F.docker%2Frun%2Fdocker.sock
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] 🐳 Sending ping request to host: http+unix://%2Fhome%2Fxtremek%2F.docker%2Frun%2Fdocker.sock
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] Sending URL: http+unix://%2Fhome%2Fxtremek%2F.docker%2Frun%2Fdocker.sock/_ping|GET, Body: null
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] Resolving Docker host: http+unix://%2Fhome%2Fxtremek%2F.docker%2Fdesktop%2Fdocker.sock
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] 🐳 Sending ping request to host: http+unix://%2Fhome%2Fxtremek%2F.docker%2Fdesktop%2Fdocker.sock
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] Sending URL: http+unix://%2Fhome%2Fxtremek%2F.docker%2Fdesktop%2Fdocker.sock/_ping|GET, Body: null
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] Resolving Docker host: http+unix://%2Frun%2Fuser%2F1000%2Fdocker.sock
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] 🐳 Sending ping request to host: http+unix://%2Frun%2Fuser%2F1000%2Fdocker.sock
2024-10-19T14:56:17-0400 debug TestContainersTests : [Testcontainers] Sending URL: http+unix://%2Frun%2Fuser%2F1000%2Fdocker.sock/_ping|GET, Body: null
2024-10-19T14:56:17-0400 info TestContainersTests : [Testcontainers] 🐳 Resolved Docker host at: /var/run/docker.sock
2024-10-19T14:56:27-0400 info TestContainersTests : [Testcontainers] 🐳 Pulling image redis:latest...
2024-10-19T14:56:27-0400 debug TestContainersTests : [Testcontainers] Sending URL: http+unix://%2Fvar%2Frun%2Fdocker.sock/images/create?tag=latest&fromImage=redis|POST, Body: null
2024-10-19T14:56:27-0400 debug TestContainersTests : [Testcontainers] 📦 Creating container using configuration: ContainerConfig(Hostname: nil, Domainname: nil, User: nil, AttachStdin: nil, AttachStdout: nil, AttachStderr: nil, Tty: nil, OpenStdin: nil, StdinOnce: nil, Env: nil, Cmd: nil, Entrypoint: nil, Image: "redis:latest", Labels: Optional(["org.testcontainers": "true", "org.testcontainers.version": "0.0.1", "org.testcontainers.lang": "swift"]), Volumes: nil, WorkingDir: nil, NetworkDisabled: nil, MacAddress: nil, ExposedPorts: nil, StopSignal: nil, StopTimeout: nil, HostConfig: Optional(Testcontainers.HostConfig(Binds: nil, Links: nil, Memory: nil, MemorySwap: nil, MemoryReservation: nil, NanoCpus: nil, CpuPercent: nil, CpuShares: nil, CpuPeriod: nil, CpuRealtimePeriod: nil, CpuRealtimeRuntime: nil, CpuQuota: nil, CpusetCpus: nil, CpusetMems: nil, MaximumIOps: nil, MaximumIOBps: nil, BlkioWeight: nil, BlkioWeightDevice: nil, BlkioDeviceReadBps: nil, BlkioDeviceReadIOps: nil, BlkioDeviceWriteBps: nil, BlkioDeviceWriteIOps: nil, DeviceRequests: nil, MemorySwappiness: nil, OomKillDisable: nil, OomScoreAdj: nil, PidMode: nil, PidsLimit: nil, PortBindings: Optional(["6379/tcp": [Testcontainers.PortBinding(HostPort: Optional("0"))]]), PublishAllPorts: nil, Privileged: nil, ReadonlyRootfs: nil, Dns: nil, DnsOptions: nil, DnsSearch: nil, VolumesFrom: nil, CapAdd: Optional(["NET_ADMIN"]), CapDrop: nil, GroupAdd: nil, RestartPolicy: nil, AutoRemove: nil, NetworkMode: nil, Devices: nil, Ulimits: nil, LogConfig: nil, SecurityOpt: nil, StorageOpt: nil, CgroupParent: nil, VolumeDriver: nil, ShmSize: nil)), NetworkingConfig: nil)
2024-10-19T14:56:27-0400 debug TestContainersTests : [Testcontainers] Sending URL: http+unix://%2Fvar%2Frun%2Fdocker.sock/containers/create|POST, Body: {"Labels":{"org.testcontainers.version":"0.0.1","org.testcontainers.lang":"swift","org.testcontainers":"true"},"Image":"redis:latest","HostConfig":{"CapAdd":["NET_ADMIN"],"PortBindings":{"6379\/tcp":[{"HostPort":"0"}]}}}
2024-10-19T14:56:27-0400 info TestContainersTests : [Testcontainers] 📦 Created container: 9312e6f108f75ee2fc479bb5dcf8e2d6cf035bf9f5b685c92fb69ee1c7f072c8
2024-10-19T14:56:27-0400 info TestContainersTests : [Testcontainers] 📦 Starting container 9312e6f108f75ee2fc479bb5dcf8e2d6cf035bf9f5b685c92fb69ee1c7f072c8...
2024-10-19T14:56:27-0400 debug TestContainersTests : [Testcontainers] Sending URL: http+unix://%2Fvar%2Frun%2Fdocker.sock/containers/9312e6f108f75ee2fc479bb5dcf8e2d6cf035bf9f5b685c92fb69ee1c7f072c8/start|POST, Body: null
2024-10-19T14:56:28-0400 debug TestContainersTests : [Testcontainers] 🔍 Inspecting container 9312e6f108f75ee2fc479bb5dcf8e2d6cf035bf9f5b685c92fb69ee1c7f072c8...
2024-10-19T14:56:28-0400 debug TestContainersTests : [Testcontainers] Sending URL: http+unix://%2Fvar%2Frun%2Fdocker.sock/containers/9312e6f108f75ee2fc479bb5dcf8e2d6cf035bf9f5b685c92fb69ee1c7f072c8/json?size=false|GET, Body: null
2024-10-19T14:56:28-0400 info TestContainersTests : [Testcontainers] 📦 Stopping container 9312e6f108f75ee2fc479bb5dcf8e2d6cf035bf9f5b685c92fb69ee1c7f072c8...
2024-10-19T14:56:28-0400 debug TestContainersTests : [Testcontainers] Sending URL: http+unix://%2Fvar%2Frun%2Fdocker.sock/containers/9312e6f108f75ee2fc479bb5dcf8e2d6cf035bf9f5b685c92fb69ee1c7f072c8/stop|POST, Body: null
2024-10-19T14:56:38-0400 info TestContainersTests : [Testcontainers] 📦 Removing container 9312e6f108f75ee2fc479bb5dcf8e2d6cf035bf9f5b685c92fb69ee1c7f072c8...
2024-10-19T14:56:38-0400 debug TestContainersTests : [Testcontainers] Sending URL: http+unix://%2Fvar%2Frun%2Fdocker.sock/containers/9312e6f108f75ee2fc479bb5dcf8e2d6cf035bf9f5b685c92fb69ee1c7f072c8?force=true|DELETE, Body: null
Test Case 'TestContainersTests.test_start_ThenRemoveContainer_shouldBeSuccess' passed (21.046 seconds)
```

So, I wonder if some of this can be put under `.trace` level logging. But I'd like to continue tweaking this. A few other things I did here are:

 - Make the `GenericContainer` constructor throwing so that if a Docker host cannot be resolved, we cannot have a GenericContainer instance that is useless.
 - Made getting the Docker info and version optional in the `GenericContainer.start` method. This is not needed but it could be nice to have. However it is disabled by default.
 - Made the `TestContainersTests` use a logger and pass this to each `GenericContainer` instance created. The logLevel can be adjusted in the constructor to see the difference in logging. This logger is passed from `GenericContainer` all the way down the stack, so with one logger you can control everything in the library.

Please have a look and let me know what you think. I hope it can be improved even further, as there are still things can be done for log levels, verbosity, emoji, and more.