### PR TITLE
Add `Sendable` conformance for Models used publicly

### DIFF
--- a/Sources/Testcontainers/Docker/Models/ContainerInfo.swift
+++ b/Sources/Testcontainers/Docker/Models/ContainerInfo.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ContainerInfo: Decodable {
+public struct ContainerInfo: Decodable, Sendable {
     public let Id: String
     public let Names: [String]
     public let Image: String
@@ -25,22 +25,22 @@ public struct ContainerInfo: Decodable {
 
 public extension ContainerInfo {
     
-    struct HostConfig: Decodable {
+    struct HostConfig: Decodable, Sendable {
         public let NetworkMode: String
     }
     
-    struct Port: Decodable {
+    struct Port: Decodable, Sendable {
         public let IP: String
         public let PrivatePort: Int
         public let PublicPort: Int
         public let `Type`: String
     }
     
-    struct NetworkSettings: Decodable {
+    struct NetworkSettings: Decodable, Sendable {
         public let Networks: [String: NetworkInfo]
     }
     
-    struct NetworkInfo: Decodable {
+    struct NetworkInfo: Decodable, Sendable {
         public let IPAMConfig: String?
         public let Links: String?
         public let Aliases: String?
@@ -55,7 +55,7 @@ public extension ContainerInfo {
         public let MacAddress: String
     }
     
-    struct Mount: Decodable {
+    struct Mount: Decodable, Sendable {
         public let Name: String?
         public let `Type`: String
         public let Source: String

--- a/Sources/Testcontainers/Docker/Models/ContainerInspectInfo.swift
+++ b/Sources/Testcontainers/Docker/Models/ContainerInspectInfo.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ContainerInspectInfo: Decodable {
+public struct ContainerInspectInfo: Decodable, Sendable {
     public let Id: String
     public let Created: String
     public let Path: String
@@ -35,7 +35,7 @@ public struct ContainerInspectInfo: Decodable {
 
 public extension ContainerInspectInfo {
     
-    struct State: Decodable {
+    struct State: Decodable, Sendable {
         public let Status: String
         public let Running: Bool
         public let Paused: Bool
@@ -49,7 +49,7 @@ public extension ContainerInspectInfo {
         public let FinishedAt: String
     }
     
-    struct HostConfig: Decodable {
+    struct HostConfig: Decodable, Sendable {
         public let Binds: [String]?
         public let ContainerIDFile: String
         public let LogConfig: LogConfig
@@ -115,34 +115,34 @@ public extension ContainerInspectInfo {
         public let ReadonlyPaths: [String]
     }
     
-    struct LogConfig: Decodable {
+    struct LogConfig: Decodable, Sendable {
         let `Type`: String
         public let Config: [String: String]
     }
     
-    struct PortBinding: Decodable {
+    struct PortBinding: Decodable, Sendable {
         public let HostIp: String
         public let HostPort: String
     }
     
-    struct RestartPolicy: Decodable {
+    struct RestartPolicy: Decodable, Sendable {
         public let Name: String
         public let MaximumRetryCount: Int
     }
     
-    struct GraphDriver: Decodable {
+    struct GraphDriver: Decodable, Sendable {
         public let Data: GraphDriverData?
         public let Name: String
     }
     
-    struct GraphDriverData: Decodable {
+    struct GraphDriverData: Decodable, Sendable {
         public let LowerDir: String
         public let MergedDir: String
         public let UpperDir: String
         public let WorkDir: String
     }
     
-    struct Mount: Decodable {
+    struct Mount: Decodable, Sendable {
         public let Name: String?
         public let `Type`: String
         public let Source: String
@@ -153,7 +153,7 @@ public extension ContainerInspectInfo {
         public let Propagation: String
     }
     
-    struct Config: Decodable {
+    struct Config: Decodable, Sendable {
         public let Hostname: String
         public let Domainname: String
         public let User: String
@@ -174,7 +174,7 @@ public extension ContainerInspectInfo {
         public let Labels: [String: String]
     }
     
-    struct NetworkSettings: Decodable {
+    struct NetworkSettings: Decodable, Sendable {
         public let Bridge: String
         public let SandboxID: String
         public let SandboxKey: String
@@ -195,7 +195,7 @@ public extension ContainerInspectInfo {
         public let Networks: [String: Network]
     }
     
-    struct Network: Decodable {
+    struct Network: Decodable, Sendable {
         public let IPAMConfig: String?
         public let Links: String?
         public let Aliases: String?

--- a/Sources/Testcontainers/Docker/Models/DockerImageName.swift
+++ b/Sources/Testcontainers/Docker/Models/DockerImageName.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct DockerImageName {
+public struct DockerImageName: Sendable {
 
     public let name: String
     public let tag: String

--- a/Sources/Testcontainers/Docker/Models/Info.swift
+++ b/Sources/Testcontainers/Docker/Models/Info.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Info: Decodable {
+public struct Info: Decodable, Sendable {
     let ServerVersion: String
     let OperatingSystem: String
     let MemTotal: Int64

--- a/Sources/Testcontainers/Docker/Models/Version.swift
+++ b/Sources/Testcontainers/Docker/Models/Version.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-public struct Version: Decodable {
+public struct Version: Decodable, Sendable {
     let ApiVersion: String
 }


### PR DESCRIPTION
I am starting to use testcontainers-swift for my [swift-rabbitmq](https://github.com/xtremekforever/swift-rabbitmq/blob/%2318-unit-testing-and-ci/Tests/Utils/RabbitMqTestContainer.swift) package, and I found that since I am using Swift 6.0 and some structs in testcontainers-swift were not marked `Sendable`, I got warnings.

This PR simply adds `Sendable` to all structs in the Sources/Models/ directory, which silences these errors are ensures the structs are safe.

I plan to continue and look at wait strategies a bit later, but for now what is provided works quite well for running tests both locally and in the CI!

## Summary by Sourcery

New Features:
- Make public models `Sendable` to improve compatibility with Swift 6.0 concurrency features.